### PR TITLE
Correct directory name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 git clone this repository, cd into it, and then run
 
 	bundle
-	./u install to path
+	./U install to path
 
 This will symlink the "u" executable to "/usr/local/bin/u".
 Assuming "/usr/local/bin/u" is in your $PATH you can now run "u" from anywhere on the command line.


### PR DESCRIPTION
The repository name is `U`, which is what gets used when cloning. On case-insensitive file systems this isn't a problem, but the documentation should be corrected to mitigate any future issues.